### PR TITLE
AIM-186 request_id middleware setting & test.

### DIFF
--- a/main.py
+++ b/main.py
@@ -28,8 +28,8 @@ import traceback
 # Context variables import
 from vlm_model.context_var import request_id_ctx_var
 
-# ASGI types import
-from starlette.types import ASGIApp, Receive, Scope, Send
+# Middleware import
+from vlm_model.middleware import RequestIDMiddleware
 
 app = FastAPI()
 
@@ -50,18 +50,6 @@ app.add_middleware(
     allow_headers=["*"],
     allow_credentials=False,  # credentials를 반드시 False로 설정
 )
-
-# Request ID 미들웨어: 각 요청에 고유한 ID와 클라이언트 IP를 설정
-class RequestIDMiddleware:
-    def __init__(self, app: ASGIApp):
-        self.app = app
-
-    async def __call__(self, scope: Scope, receive: Receive, send: Send):
-        if scope["type"] == "http":
-            request = Request(scope, receive=receive)
-            request_id = request.headers.get("X-User-ID", "unknown")
-            request_id_ctx_var.set(request_id)
-        await self.app(scope, receive, send)
 
 # Request ID 미들웨어 추가
 app.add_middleware(RequestIDMiddleware)

--- a/vlm_model/context_var.py
+++ b/vlm_model/context_var.py
@@ -3,5 +3,5 @@
 import contextvars
 
 # 요청별 고유 ID를 저장하는 ContextVar
-request_id_ctx_var = contextvars.ContextVar('request_id', default=None)
-# client_ip_ctx_var = contextvars.ContextVar('client_ip', default=None)
+request_id_ctx_var = contextvars.ContextVar('request_id', default='unknown')
+# client_ip_ctx_var = contextvars.ContextVar('client_ip', default='unknown')

--- a/vlm_model/middleware.py
+++ b/vlm_model/middleware.py
@@ -1,0 +1,29 @@
+# vlm_model/middleware.py
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.types import ASGIApp, Receive, Scope, Send
+from vlm_model.context_var import request_id_ctx_var
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Request ID 미들웨어: 각 요청에 고유한 ID와 클라이언트 IP를 설정
+class RequestIDMiddleware(BaseHTTPMiddleware):
+    """
+    요청 헤더에서 'X-Request-ID'를 추출하여 ContextVar에 설정하는 미들웨어.
+    """
+    async def dispatch(self, request: Request, call_next):
+        # 요청 헤더에서 'X-Request-ID' 추출 (헤더 이름은 클라이언트와 협의하여 설정)
+        request_id = request.headers.get("X-Request-ID", "unknown")
+        # ContextVar에 설정
+        token = request_id_ctx_var.set(request_id)
+        logger.debug(f"RequestIDMiddleware: set request_id to {request_id}")
+
+        try:
+            response = await call_next(request)
+            return response
+        finally:
+            # 요청 처리 후 ContextVar 복구
+            request_id_ctx_var.reset(token)
+            logger.debug("RequestIDMiddleware: reset request_id to previous value")

--- a/vlm_model/schemas/feedback.py
+++ b/vlm_model/schemas/feedback.py
@@ -19,7 +19,7 @@ class FeedbackSections(BaseModel):
     movement: FeedbackDetails # 갑작스러운 행동 및 움직임
 
 class FeedbackFrame(BaseModel):
-    video_id: str
+    video_id: str # video_id 추가
     frame_index: int
     timestamp: str  # 예: "0m 0s"
     feedback_text: FeedbackSections  # 피드백 섹션 구조로 변환된 텍스트


### PR DESCRIPTION
# ☝️Issue Number

- #58 

# 🔎 Key Changes
- RequestIDMiddleware 분리: model/middleware.py 파일에 RequestIDMiddleware 클래스를 정의.
- pronun_model.middleware 에서 RequestIDMiddleware를 임포트하고, FastAPI 애플리케이션에 추가.
- main.py 내의 중복된 RequestIDMiddleware 클래스 정의를 제거.
- uvicorn으로 실행후, curl 명령어로 테스트

# 💌 To Reviewers
- 클라이언트에서 X-User-ID 헤더를 포함하여 API 요청을 curl로 보내는 테스트를 진행했고, log에 request_id log가 잘 출력되는걸 확인했습니다.
- 테스트한 내용 포함해서 자세한건 Notion Ticket을 확인해주세요!
https://www.notion.so/Request_id-Middleware-Setting-1565deb8ae85806b99b6f7720cdff049?pvs=4
